### PR TITLE
Introduce a "NoContext" finish declaration in flexpiler::common::rust…

### DIFF
--- a/flexpiler/src/common/rustc/deserializer/context.rs
+++ b/flexpiler/src/common/rustc/deserializer/context.rs
@@ -2,7 +2,7 @@
 
 #[derive(PartialEq)]
 pub enum Context {
-    Freestanding,   // Block was ended by a ' ', '\t' or '\n'
+    Freestanding,   // Block was ended by a ' ', '\t', '\n' or the end of the reader
     Separator,      // Block ended with a ','
     ArgumentStart,  // Block ended with a '('
     ArgumentEnd,    // Block ended with a ')'


### PR DESCRIPTION
…c::block::IdentifierWithVariableFinish. This leads that block to return successful parsing even if there was no character to signify its end upon calling to_result().